### PR TITLE
Generate code for Scenario Outlines as well

### DIFF
--- a/src/modules/generator.ts
+++ b/src/modules/generator.ts
@@ -19,7 +19,8 @@ function generateCommandsFromFeatureAsText(
 	}
 }
 function areScenariosPresentIn(feature) {
-	return feature.scenarios.length > 0;
+	return feature.scenarios.length +
+		feature.scenarioOutlines.length > 0;
 }
 function generateCommands(
 	feature,
@@ -71,7 +72,11 @@ function generateScenarioCommands(
 ) {
 	let commands = [];
 	feature.scenarios = filterScenariosFrom(
-		feature,
+		feature.scenarios,
+		selectionInformation
+	);
+	feature.scenarioOutlines = filterScenariosFrom(
+		feature.scenarioOutlines,
 		selectionInformation
 	);
 	commands = generateCommandsFrom(feature);
@@ -82,10 +87,10 @@ function generateScenarioCommands(
 	);
 }
 function filterScenariosFrom(
-	feature,
+	scenarios,
 	selectionInformation
 ) {
-	return feature.scenarios.filter(scenario => {
+	return scenarios.filter(scenario => {
 		const { lineNumber } = scenario;
 		const { start, end } = selectionInformation;
 		
@@ -94,7 +99,11 @@ function filterScenariosFrom(
 	});
 }
 function generateCommandsFrom(feature) {
-	return feature.scenarios.map(scenario =>
+	return feature.scenarios
+		.concat(feature.scenarioOutlines)
+		.sort((a, b) =>
+			Math.sign(a.lineNumber - b.lineNumber))
+		.map(scenario =>
 		generateCodeFromFeature(
 			feature,
 			scenario.lineNumber

--- a/src/utilities/sample/example.feature
+++ b/src/utilities/sample/example.feature
@@ -1,9 +1,16 @@
 Feature: Rocket Launching
 
-	Scenario: Launching a SpaceX rocket one
+	Scenario Outline: Launching a SpaceX rocket
 		Given I am Elon Musk attempting to launch a rocket into space
+		When I launch the rocket <number>
+		Then the launch is a <outcome>
 
-	Scenario: Launching a SpaceX rocket two
+		Examples: Rocket examples
+			| number | outcome |
+			| one    | failure |
+			| two    | success |
+
+	Scenario: Launching SpaceX rocket two
 		Given I am Elon Musk attempting to launch a rocket into space
 		When I launch the rocket
 		Then the rocket should end up in space


### PR DESCRIPTION
The current extension only generates code for Scenarios, so I've made a few changes for it to also generate code for Scenario Outlines. The generated code keeps the order used on the feature file.